### PR TITLE
Correction du chemin d'une dépendance

### DIFF
--- a/module/Administration/view/layout/adminlayout.phtml
+++ b/module/Administration/view/layout/adminlayout.phtml
@@ -25,7 +25,7 @@
         <?php echo $this->headScript()->prependFile($this->basePath() . '/assets/js/application.js')
                                       ->prependFile($this->basePath() . '/components/jquery-stupid-table/stupidtable.min.js')  
         							  ->prependFile($this->basePath() . '/components/pick-a-color/build/1.2.3/js/pick-a-color-1.2.3.min.js')
-        							  ->prependFile($this->basePath() . '/components/pick-a-color/build/dependencies/tinycolor-0.9.15.min.js')
+        							  ->prependFile($this->basePath() . '/components/tinycolor/dist/tinycolor-min.js')
                         ->prependFile($this->basePath() . '/components/bootstrap-material-datetimepicker/js/bootstrap-material-datetimepicker.js')
                         ->prependFile($this->basePath() . '/components/momentjs/min/moment.min.js')
                         ->prependFile($this->basePath() . '/components/jquery-mousewheel/jquery.mousewheel.min.js')


### PR DESCRIPTION
Modification du chemin de tinycolor, qui provoquait un problème d'affichage des checkbox dans le formulaire de modification des catégories
