### PR TITLE
Implémentation du "Mode confirmé"

### DIFF
--- a/data/DoctrineORMModule/Migrations/Version20151211121018.php
+++ b/data/DoctrineORMModule/Migrations/Version20151211121018.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DoctrineORMModule\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20151211121018 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE categories ADD timelineconfirmed TINYINT(1) NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE categories DROP timelineconfirmed');
+    }
+}

--- a/module/Administration/public/assets/js/categories.js
+++ b/module/Administration/public/assets/js/categories.js
@@ -43,11 +43,28 @@ var categories = function(url){
 	$(".mod").on('click', function(){
 		$("#form-title").html("Modification de "+$(this).data('name'));
 		$("#form").load(url+'/categories/form'+'?id='+$(this).data('id'),
-				function(){
-					$("#form").find(".pick-a-color").pickAColor();
-					$.material.checkbox();
-			});	
-	});
+                        function(){
+                                $("#form").find(".pick-a-color").pickAColor();
+                                $.material.checkbox();
+                                $('#tcdiv').tooltip();
+                                $('.form-control[name="timeline"]').change(function () {
+                                        if (this.checked) {
+                                                $('.form-control[name="timelineconfirmed"]').prop('disabled', false);
+                                                $('#tcdiv').css({ opacity: 1 });
+                                        } else {
+                                                $('.form-control[name="timelineconfirmed"]').prop('disabled', true).attr('checked', false);
+                                                $('#tcdiv').css({ opacity: 0.5 });
+                                        }
+                                });
+                                if ($('.form-control[name="timeline"]').checked) {
+                                        $('.form-control[name="timelineconfirmed"]').prop('disabled', false);
+                                        $('#tcdiv').css({ opacity: 1 });
+                                } else {
+                                        $('.form-control[name="timelineconfirmed"]').prop('disabled', true).attr('checked', false);
+                                        $('#tcdiv').css({ opacity: 0.5 });
+                                }
+                });
+        });
 
 	$("#add-cat").on('click', function(evt){
 		$("#form-title").html("Nouvelle catégorie");

--- a/module/Administration/view/administration/categories/form.phtml
+++ b/module/Administration/view/administration/categories/form.phtml
@@ -28,6 +28,8 @@ echo $this->controlGroup($this->form->get('compactmode'));
 
 echo $this->controlGroup($this->form->get('timeline'));
 
+echo $this->controlGroup($this->form->get('timelineconfirmed'));
+
 echo $this->controlGroup($this->form->get('parent'));
 if($this->system) {
     echo "</div>";

--- a/module/Administration/view/administration/categories/form.phtml
+++ b/module/Administration/view/administration/categories/form.phtml
@@ -28,7 +28,9 @@ echo $this->controlGroup($this->form->get('compactmode'));
 
 echo $this->controlGroup($this->form->get('timeline'));
 
+echo '<div id="tcdiv" title="Seulement si Timeline est actif" data-toggle="tooltip">';
 echo $this->controlGroup($this->form->get('timelineconfirmed'));
+echo '</div>';
 
 echo $this->controlGroup($this->form->get('parent'));
 if($this->system) {

--- a/module/Application/src/Application/Entity/Category.php
+++ b/module/Application/src/Application/Entity/Category.php
@@ -105,7 +105,8 @@ class Category
     /**
      * @ORM\Column(type="boolean")
      * @Annotation\Type("Zend\Form\Element\Checkbox")
-     * @Annotation\Options({"label":"Timeline si confirmé"})
+     * @Annotation\Options({"label":"Mode confirmé"})
+     * @Annotation\Attributes({"id":"timelineconfirmed","title":"Disponible uniquement si Timeline est actif", "data-toggle":"tooltip"})
      */
     protected $timelineconfirmed;
 

--- a/module/Application/src/Application/Entity/Category.php
+++ b/module/Application/src/Application/Entity/Category.php
@@ -103,6 +103,13 @@ class Category
     protected $timeline;
 
     /**
+     * @ORM\Column(type="boolean")
+     * @Annotation\Type("Zend\Form\Element\Checkbox")
+     * @Annotation\Options({"label":"Timeline si confirmé"})
+     */
+    protected $timelineconfirmed;
+
+    /**
      * @ORM\Column(type="string")
      * @Annotation\Type("Zend\Form\Element\Text")
      * @Annotation\Required({"required":"true"})
@@ -255,9 +262,19 @@ class Category
         return $this->timeline;
     }
 
+    public function isTimelineConfirmed()
+    {
+        return $this->timelineconfirmed;
+    }
+
     public function setTimeline($timeline)
     {
         $this->timeline = $timeline;
+    }
+
+    public function setTimelineConfirmed($timelineconfirmed)
+    {
+        $this->timelineconfirmed = $timelineconfirmed;
     }
 
     public function isCompactMode()

--- a/module/Application/src/Application/Repository/EventRepository.php
+++ b/module/Application/src/Application/Repository/EventRepository.php
@@ -82,6 +82,18 @@ class EventRepository extends ExtendedRepository
                 ->eq('p.timeline', true))));
         }
         
+        // restriction éventuelle aux événements confirmés si timelineconfirmed, seulement en timeline (cats est null)
+        if(!$cats)
+        {
+        $qb->andWhere($qb->expr()->orX(
+                $qb->expr()->neq('c.timelineconfirmed',true),
+                $qb->expr()->andX(
+                        $qb->expr()->eq('c.timelineconfirmed',true),
+                        $qb->expr()->in('e.status',array(2,3)))
+                )
+            );
+        }
+                
         // restriction à tous les evts modifiés depuis $lastmodified qqsoit la date de l'évènement
         if ($lastmodified) {
             $lastmodified = new \DateTime($lastmodified);


### PR DESCRIPTION
Pour améliorer la lisibilité, une catégorie en "mode confirmé" n'affichera que les événements confirmés. Pour visualiser d'éventuels événements programmés/nouveaux, il faut y accéder spécifiquement, par exemple depuis un onglet.
