### PR TITLE
Correctif mode confirmé: restriction aux événements programmé, prise …

### DIFF
--- a/module/Application/src/Application/Repository/EventRepository.php
+++ b/module/Application/src/Application/Repository/EventRepository.php
@@ -86,7 +86,8 @@ class EventRepository extends ExtendedRepository
                     ->neq('c.timelineconfirmed', true), $qb->expr()
                     ->andX($qb->expr()
                         ->eq('c.timelineconfirmed', true), $qb->expr()
-                        ->in('e.status', array(2,3))
+                        ->in('e.status', array(2,3,4)), $qb->expr()
+                        ->eq('e.scheduled',true)
                     )
                 )
             );


### PR DESCRIPTION
…en compte du statut annulé.

Le statut annulé n'a pas intếret à être caché de la timeline ; dès lors qu'un événement a été confirmé une fois, il y reste.
En revanche, le comportement du mode confirmé doit être restreint aux événements programmés.
